### PR TITLE
fix: use correct metadata field to populate RNA levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ const parseModelFiles = (modelDir) => {
   const metadataSection = metadata.metaData || metadata.metadata;
   const model = toLabelCase(metadataSection.short_name);
   const version = `V${metadataSection.version.replace(/\./g, '_')}`;
-  const isHuman = metadataSection.organism === 'Homo sapiens';
+  const isHuman = metadataSection.short_name === 'Human-GEM';
 
   const prefix = `${model}${version}`;
   const outputPath = `./data/${prefix}.`;


### PR DESCRIPTION
The `isHuman` from  `const isHuman = metadataSection.organism === 'Homo sapiens';` is used to populate the HPA RNA levels. In the newer data files, the `organism` field is missing, which means `isHuman` is always false, which in turn means the HPA RNA levels do not get populated. This PR uses the `short_name` field instead, which exists in both the older and newer data files.